### PR TITLE
디자인 초안이 나옴에 따른 컴포넌트 관계 설정 및 컴포넌트 레이아웃 재조정 (이슈 #1)

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -20,9 +20,10 @@ const Router = () => {
 }
 
 const Container = styled.main`
+  margin: 0 auto;
+  max-width: 1200px;
   position: relative;
   top:60px;
-  padding: 10px;
 `
 
 export default Router

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,4 +1,4 @@
-.header__link_wrapper{
+.header__link-wrapper{
   display:flex;
   justify-content: flex-end;
   margin-right: 3rem;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,18 +9,25 @@ const Header = () => {
 
   return (
     <Container>
-      <ul className="header__link-wrapper">
-        {
-          pageLink.map((link,idx)=>
-            <li key={pageName[idx]} >
-              <Link to={`/${link}`}> {pageName[idx]} </Link>
-            </li>  
-          )
-        }
-      </ul>
+      <InnerContainer>
+        <ul className="header__link-wrapper">
+          {
+            pageLink.map((link,idx)=>
+              <li key={pageName[idx]} >
+                <Link to={`/${link}`}> {pageName[idx]} </Link>
+              </li>  
+            )
+          }
+        </ul>
+      </InnerContainer>
     </Container>
   )
 }
+const InnerContainer = styled.div`
+  margin: 0 auto;
+  max-width: 1200px;
+  
+`
 
 const Container = styled.nav`
   position: fixed;
@@ -29,7 +36,7 @@ const Container = styled.nav`
   right: 0;
   width: 100%;
   height: 60px;
-  background-color: #999;
+  border-bottom: 2px solid #ddd;
   font-size: 1rem;
   z-index: 10;
 `

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
 const InnerContainer = styled.div`
   margin: 0 auto;
   max-width: 1200px;
-  
+
 `
 
 const Container = styled.nav`
@@ -39,6 +39,7 @@ const Container = styled.nav`
   border-bottom: 2px solid #ddd;
   font-size: 1rem;
   z-index: 10;
+  background-color: #fff;
 `
 
 export default Header

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ const Header = () => {
 
   return (
     <Container>
-      <ul className="header__link_wrapper">
+      <ul className="header__link-wrapper">
         {
           pageLink.map((link,idx)=>
             <li key={pageName[idx]} >

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,4 +1,4 @@
-.sidebar__link_wrapper{
+.sidebar__link-wrapper{
   display:flex;
   flex-flow: column;
   gap: 20px;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar = () => {
     // Wiki 사이드바 
     return (
       <Container>
-        <ul className="sidebar__link_wrapper">
+        <ul className="sidebar__link-wrapper">
           {
             sideLink.map((link,idx)=>
               <li key={sideName[idx]} >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,13 +39,13 @@ const Sidebar = () => {
 
 const Container = styled.aside`
   position: fixed;
-  left: 0;
-  top: 60px;
-  bottom: 0;
   z-index: 9;
-  width: 140px;
-  height: 100%;
-  background-color: #ddd;
+  width: 180px;
+  height: 100vh;
+  border-right: 2px solid #ddd;
+  box-sizing: border-box;
+  padding: 5px;
+
 `
 
 

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -53,9 +53,11 @@ Vivamus sed aliquet lacus. Aenean pharetra quis mi vel tempor. Duis id velit ali
 
 const Container = styled.section`
   position: relative;
-  left: 140px;
+  left: 180px;
   height: calc(100% - 60px);
-  width: calc(100% - 140px);
+  width: calc(100% - 180px);
+  padding: 5px;
+  box-sizing: border-box;
 `
 
 export default Gallery

--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -8,7 +8,7 @@ import Curriculum from '../components/Curriculum'
 const Wiki = () => {
   
   return (
-    <WikiContainer>
+    <>
       <Sidebar />
       <Container>
         <Routes>
@@ -16,13 +16,9 @@ const Wiki = () => {
           <Route path="교육과정" element={<Curriculum />}></Route>
         </Routes>
       </Container>
-    </WikiContainer>
+    </>
   )
 }
-
-const WikiContainer = styled.div`
-  display:flex;
-`
 
 const Container = styled.section`
   position: relative;

--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -8,7 +8,7 @@ import Curriculum from '../components/Curriculum'
 const Wiki = () => {
   
   return (
-    <>
+    <WikiContainer>
       <Sidebar />
       <Container>
         <Routes>
@@ -16,15 +16,21 @@ const Wiki = () => {
           <Route path="교육과정" element={<Curriculum />}></Route>
         </Routes>
       </Container>
-    </>
+    </WikiContainer>
   )
 }
 
+const WikiContainer = styled.div`
+  display:flex;
+`
+
 const Container = styled.section`
   position: relative;
-  left: 140px;
+  left: 180px;
   height: calc(100% - 60px);
-  width: calc(100% - 140px);
+  width: calc(100% - 180px);
+  padding: 5px;
+  box-sizing: border-box;
 `
 
 export default Wiki


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#1 디자인 초안이 나옴에 따른 컴포넌트 관계 설정 및 컴포넌트 레이아웃 재조정
close #1 

## 작업 내용 (변경 사항)
- 전체에 Max-width 1200px 속성 추가
- 각 컴포넌트 별 레이아웃 재조정 (padding과 box-sizing 추가)
- Header, Sidebar 등 CSS 디자인 적용

## 스크린샷
![image](https://github.com/TaePoong719/fastcampus-wiki/assets/98576512/aa727f21-4c4e-4534-bb9e-fcf1d8a7a56f)
![image](https://github.com/TaePoong719/fastcampus-wiki/assets/98576512/047a40a3-8fa0-452f-915d-3933c0eb5765)
![image](https://github.com/TaePoong719/fastcampus-wiki/assets/98576512/a6fc56a2-8de9-499c-9dc0-6eb6caa6397e)


## 테스트 결과
각 페이지 별 정상 작동

## 리뷰 요청 사항
- Gallery와 Wiki페이지와 Sidebar 컴포넌트의 Container에 padding과 box-sizing 속성을 추가 했습니다. 아마 작업 하시던 것에 영향을 끼치진 않을 것으로 보이나 Conflict 있는지 확인 부탁드립니다.

- Header 컴포넌트에 InnerContainer 컴포넌트를 추가하였습니다. 아마 영향을 끼치진 않을 것으로 보이나, Conflict 있는지 확인 부탁드립니다.
