### PR TITLE
Feature/#8

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,6 +1,6 @@
-.header__link_wrapper{
-  display:flex;
+.header__link_wrapper {
+  display: flex;
   justify-content: flex-end;
   margin-right: 3rem;
-  gap: 20px; 
+  gap: 20px;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,28 +1,45 @@
-import React from 'react'
-import styled from 'styled-components'
-import { Link } from 'react-router-dom'
-import './Header.css'
+import React, { useState } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { Modal } from "./Modal";
+import "./Header.css";
 
 const Header = () => {
-  const pageLink = ["", "Wiki/", "Gallery"]
-  const pageName = ["Home", "Wiki", "Gallery"]
+  const pageLink = ["", "Wiki/", "Gallery"];
+  const pageName = ["Home", "Wiki", "Gallery"];
+
+  const [isModalActive, setIsModalActive] = useState(false);
+  const openModal = () => {
+    setIsModalActive(true);
+  };
 
   return (
-    <Container>
-      <ul className="header__link_wrapper">
-        {
-          pageLink.map((link,idx)=>
-            <li key={pageName[idx]} >
+    <>
+      <Container>
+        <ul className="header__link_wrapper">
+          {pageLink.map((link, idx) => (
+            <li key={pageName[idx]}>
               <Link to={`/${link}`}> {pageName[idx]} </Link>
-            </li>  
-          )
-        }
-      </ul>
-    </Container>
-  )
-}
+            </li>
+          ))}
+          <button onClick={openModal}>모달열기</button>
+        </ul>
+      </Container>
 
-const Container = styled.nav`
+      {isModalActive && (
+        <Modal
+          // modal={isModalActive}
+          setModal={setIsModalActive}
+          width="400"
+          height="200"
+          element={<div>Hello Modal!</div>}
+        />
+      )}
+    </>
+  );
+};
+
+export const Container = styled.nav`
   position: fixed;
   left: 0;
   top: 0;
@@ -32,6 +49,6 @@ const Container = styled.nav`
   background-color: #999;
   font-size: 1rem;
   z-index: 10;
-`
+`;
 
-export default Header
+export default Header;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,59 @@
+import React, { useState, Dispatch, SetStateAction } from "react";
+import styled from "styled-components";
+
+const ModalContainer = styled.div<{ width: string; height: string }>`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  left: calc(50vw - ${(props) => props.width}px / 2);
+  top: calc(50vh - ${(props) => props.height}px / 2);
+  width: ${(props) => props.width}px;
+  height: ${(props) => props.height}px;
+  padding: 8px;
+  background-color: white;
+  border-radius: 8px;
+  z-index: 200;
+  text-align: center;
+  .modal__close-btn {
+  }
+`;
+
+const ModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 50;
+`;
+
+const ModalWrapper = styled.div`
+  background-color: transparent;
+`;
+
+interface Props {
+  width: string;
+  height: string;
+  element: JSX.Element;
+  setModal: Dispatch<SetStateAction<boolean>>;
+}
+
+export const Modal = ({ width, height, element, setModal }: Props) => {
+  const disableModal = () => {
+    setModal(false);
+  };
+  return (
+    <>
+      <ModalContainer width={width} height={height}>
+        <ModalWrapper>{element}</ModalWrapper>
+        <button className="btn modal__close-btn" onClick={disableModal}>
+          닫기
+        </button>
+      </ModalContainer>
+      <ModalBackground onClick={disableModal} />
+    </>
+  );
+};
+
+// export default Modal;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
재사용가능한 모달 컴포넌트 구성 (close #8 )

## 작업 내용 (변경 사항)
- Modal.tsx 생성
- Header.tsx에  openModal 온클릭 이벤트를 가지는 버튼 및 height, width, element 내용을 지정할 수 있는 <Modal>추가

## 스크린샷
![스크린샷 2023-09-13 오후 1 42 33](https://github.com/TaePoong719/fastcampus-wiki/assets/35457850/46fc1379-d17e-4176-9b92-13bbc919adbd)
![스크린샷 2023-09-13 오후 1 42 41](https://github.com/TaePoong719/fastcampus-wiki/assets/35457850/4e441120-0417-4d87-9cae-d38c8cdf55c7)


## 테스트 결과
모달 노출 및 모달 버튼 / 외부 클릭 시 닫히는 기능 정상 작동
